### PR TITLE
Sink job label support

### DIFF
--- a/docs/BigQueryMultiTable-batchsink.md
+++ b/docs/BigQueryMultiTable-batchsink.md
@@ -42,6 +42,14 @@ write BigQuery data to this project.
 Datasets are top-level containers that are used to organize and control access to tables and views.
 If dataset does not exist, it will be created.
 
+**BQ Job Labels:** Key value pairs to be added as labels to the BigQuery job. Keys must be unique. (Macro Enabled)
+
+[job_source, type] are system defined labels used by CDAP for internal purpose and cannot be used as label keys.
+Macro format is supported. example `key1:val1,key2:val2`
+
+Keys and values can contain only lowercase letters, numeric characters, underscores, and dashes.
+For more information about labels, see [Docs](https://cloud.google.com/bigquery/docs/labels-intro#requirements).
+
 **Temporary Bucket Name:** Google Cloud Storage bucket to store temporary data in.
 It will be automatically created if it does not exist. Temporary data will be deleted after it is loaded into BigQuery.
 If the bucket was created automatically, it will be deleted after the run finishes.

--- a/docs/BigQueryTable-batchsink.md
+++ b/docs/BigQueryTable-batchsink.md
@@ -52,6 +52,14 @@ bucket will be created and then deleted after the run finishes.
 
 **GCS Upload Request Chunk Size**: GCS upload request chunk size in bytes. Default value is 8388608 bytes.
 
+**BQ Job Labels:** Key value pairs to be added as labels to the BigQuery job. Keys must be unique. (Macro Enabled)
+
+[job_source, type] are system defined labels used by CDAP for internal purpose and cannot be used as label keys.
+Macro format is supported. example `key1:val1,key2:val2`
+
+Keys and values can contain only lowercase letters, numeric characters, underscores, and dashes.
+For more information about labels, see [Docs](https://cloud.google.com/bigquery/docs/labels-intro#requirements).
+
 **JSON String**: List of fields to be written to BigQuery as a JSON string.
 The fields must be of type STRING. To target nested fields, use dot notation.
 For example, 'name.first' will target the 'first' field in the 'name' record. (Macro Enabled)

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/action/BigQueryExecute.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/action/BigQueryExecute.java
@@ -125,7 +125,7 @@ public final class BigQueryExecute extends AbstractBigQueryAction {
     }
 
     // Add labels for the BigQuery Execute job.
-    builder.setLabels(BigQueryUtil.getJobTags(BigQueryUtil.BQ_JOB_TYPE_EXECUTE_TAG));
+    builder.setLabels(BigQueryUtil.getJobLabels(BigQueryUtil.BQ_JOB_TYPE_EXECUTE_TAG));
 
     QueryJobConfiguration queryConfig = builder.build();
 

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySink.java
@@ -107,12 +107,17 @@ public abstract class AbstractBigQuerySink extends BatchSink<StructuredRecord, S
     bucketName = BigQuerySinkUtils.configureBucket(baseConfiguration, bucketName, runUUID.toString());
     Bucket bucket = storage.get(bucketName);
 
+    // Set user defined job label key value pair
+    String jobLabelKeyValue = getConfig().getJobLabelKeyValue();
+    if (jobLabelKeyValue != null) {
+      baseConfiguration.set(BigQueryConstants.CONFIG_JOB_LABEL_KEY_VALUE, jobLabelKeyValue);
+    }
+
     if (!context.isPreviewEnabled()) {
       BigQuerySinkUtils.createResources(bigQuery, dataset, datasetId,
                                         storage, bucket, bucketName,
                                         config.getLocation(), cmekKeyName);
     }
-
     prepareRunInternal(context, bigQuery, bucketName);
   }
 

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkConfig.java
@@ -197,12 +197,13 @@ public final class BigQuerySinkConfig extends AbstractBigQuerySinkConfig {
                              @Nullable String serviceAccountType, @Nullable String serviceFilePath,
                              @Nullable String serviceAccountJson,
                              @Nullable String dataset, @Nullable String table, @Nullable String location,
-                             @Nullable String cmekKey, @Nullable String bucket) {
+                             @Nullable String cmekKey, @Nullable String bucket, @Nullable String jobLabelKeyValue) {
     super(new BigQueryConnectorConfig(project, project, serviceAccountType,
             serviceFilePath, serviceAccountJson), dataset, cmekKey, bucket);
     this.referenceName = referenceName;
     this.table = table;
     this.location = location;
+    this.jobLabelKeyValue = jobLabelKeyValue;
   }
 
   public String getTable() {
@@ -696,6 +697,7 @@ public final class BigQuerySinkConfig extends AbstractBigQuerySinkConfig {
     private String cmekKey;
     private String location;
     private String bucket;
+    private String jobLabelKeyValue;
 
     public BigQuerySinkConfig.Builder setReferenceName(@Nullable String referenceName) {
       this.referenceName = referenceName;
@@ -746,6 +748,10 @@ public final class BigQuerySinkConfig extends AbstractBigQuerySinkConfig {
       this.bucket = bucket;
       return this;
     }
+    public BigQuerySinkConfig.Builder setJobLabelKeyValue(@Nullable String jobLabelKeyValue) {
+      this.jobLabelKeyValue = jobLabelKeyValue;
+      return this;
+    }
 
     public BigQuerySinkConfig build() {
       return new BigQuerySinkConfig(
@@ -758,7 +764,8 @@ public final class BigQuerySinkConfig extends AbstractBigQuerySinkConfig {
         table,
         location,
         cmekKey,
-        bucket
+        bucket,
+        jobLabelKeyValue
       );
     }
 

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/source/PartitionedBigQueryInputFormat.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/source/PartitionedBigQueryInputFormat.java
@@ -257,7 +257,7 @@ public class PartitionedBigQueryInputFormat extends AbstractBigQueryInputFormat<
 
     JobConfiguration config = new JobConfiguration();
     config.setQuery(queryConfig);
-    config.setLabels(BigQueryUtil.getJobTags(BigQueryUtil.BQ_JOB_TYPE_SOURCE_TAG));
+    config.setLabels(BigQueryUtil.getJobLabels(BigQueryUtil.BQ_JOB_TYPE_SOURCE_TAG));
 
     JobReference jobReference = getJobReference(configuration, bigQueryHelper, projectId, location);
 

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sqlengine/util/BigQuerySQLEngineUtils.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sqlengine/util/BigQuerySQLEngineUtils.java
@@ -357,7 +357,7 @@ public class BigQuerySQLEngineUtils {
    * @return Map containing tags for a job.
    */
   public static Map<String, String> getJobTags(String operation) {
-    Map<String, String> labels = BigQueryUtil.getJobTags(BigQueryUtil.BQ_JOB_TYPE_PUSHDOWN_TAG);
+    Map<String, String> labels = BigQueryUtil.getJobLabels(BigQueryUtil.BQ_JOB_TYPE_PUSHDOWN_TAG);
     labels.put("pushdown_operation", operation);
     return labels;
   }

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryConstants.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryConstants.java
@@ -48,4 +48,5 @@ public interface BigQueryConstants {
   String CONFIG_TEMPORARY_TABLE_NAME = "cdap.bq.source.temporary.table.name";
   String CDAP_BQ_SINK_OUTPUT_SCHEMA = "cdap.bq.sink.output.schema";
   String BQ_FQN_PREFIX = "bigquery";
+  String CONFIG_JOB_LABEL_KEY_VALUE = "cdap.bq.sink.job.label.key.value";
 }

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryUtil.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryUtil.java
@@ -36,7 +36,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.etl.api.FailureCollector;
-import io.cdap.cdap.etl.api.action.SettableArguments;
 import io.cdap.cdap.etl.api.validation.InvalidConfigPropertyException;
 import io.cdap.cdap.etl.api.validation.InvalidStageException;
 import io.cdap.cdap.etl.api.validation.ValidationFailure;
@@ -108,6 +107,10 @@ public final class BigQueryUtil {
     .put(LegacySQLTypeName.TIMESTAMP, "timestamp")
     .put(LegacySQLTypeName.NUMERIC, "decimal")
     .build();
+
+  public static final String BQ_JOB_SOURCE_TAG = "job_source";
+  public static final String BQ_JOB_TYPE_TAG = "type";
+  public static final Set<String> BQ_JOB_LABEL_SYSTEM_KEYS = ImmutableSet.of(BQ_JOB_SOURCE_TAG, BQ_JOB_TYPE_TAG);
 
   private static final Map<Schema.Type, Set<LegacySQLTypeName>> TYPE_MAP = ImmutableMap.<Schema.Type,
     Set<LegacySQLTypeName>>builder()
@@ -859,14 +862,37 @@ public final class BigQueryUtil {
   }
 
   /**
-   * Get tags for a BigQuery Job.
+   * Get labels for a BigQuery Job.
    * @param jobType the job type to set in the labels.
    * @return map containing labels for a BigQuery job launched by this plugin.
    */
-  public static Map<String, String> getJobTags(String jobType) {
+  public static Map<String, String> getJobLabels(String jobType) {
     Map<String, String> labels = new HashMap<>();
-    labels.put("job_source", "cdap");
-    labels.put("type", jobType);
+    labels.put(BQ_JOB_SOURCE_TAG, "cdap");
+    labels.put(BQ_JOB_TYPE_TAG, jobType);
+    return labels;
+  }
+
+  /**
+   * Get labels for a BigQuery Job.
+   * @param jobType the job type to set in the labels.
+   * @param userDefinedTags user defined tags to be added to the labels.
+   * @return map containing labels for a BigQuery job launched by this plugin.
+   */
+  public static Map<String, String> getJobLabels(String jobType, String userDefinedTags) {
+    Map<String, String> labels = getJobLabels(jobType);
+    if (Strings.isNullOrEmpty(userDefinedTags)) {
+        return labels;
+    }
+    for (String tag : userDefinedTags.trim().split(",")) {
+      String[] keyValue = tag.split(":");
+      if (keyValue.length == 1) {
+        labels.put(keyValue[0], "");
+      }
+      if (keyValue.length == 2) {
+        labels.put(keyValue[0], keyValue[1]);
+      }
+    }
     return labels;
   }
 

--- a/src/test/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryOutputFormatTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryOutputFormatTest.java
@@ -93,7 +93,8 @@ public class BigQueryOutputFormatTest {
                                   ArgumentMatchers.any(),
                                   ArgumentMatchers.any(JobId.class),
                                   ArgumentMatchers.any(),
-                                  ArgumentMatchers.any(Dataset.class));
+                                  ArgumentMatchers.any(Dataset.class),
+                                  ArgumentMatchers.any());
 
     FieldSetter.setField(spy, bigQueryOutputCommitter.getClass().getDeclaredField("bigQueryHelper"),
                          bigQueryHelperMock);
@@ -157,7 +158,8 @@ public class BigQueryOutputFormatTest {
               ArgumentMatchers.any(),
               ArgumentMatchers.any(JobId.class),
               ArgumentMatchers.any(),
-              ArgumentMatchers.any(Dataset.class));
+              ArgumentMatchers.any(Dataset.class),
+              ArgumentMatchers.any());
   }
 
 }

--- a/src/test/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkConfigTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkConfigTest.java
@@ -118,4 +118,189 @@ public class BigQuerySinkConfigTest {
         Assert.assertEquals(0, collector.getValidationFailures().size());
     }
 
+    @Test
+    public void testJobLabelWithDuplicateKeys() {
+        config.jobLabelKeyValue = "key1:value1,key2:value2,key1:value3";
+        config.validate(collector);
+        Assert.assertEquals(1, collector.getValidationFailures().size());
+        Assert.assertEquals("Duplicate job label key 'key1'.",
+                collector.getValidationFailures().get(0).getMessage());
+    }
+
+    @Test
+    public void testJobLabelWithDuplicateValues() {
+        config.jobLabelKeyValue = "key1:value1,key2:value2,key3:value1";
+        config.validate(collector);
+        Assert.assertEquals(0, collector.getValidationFailures().size());
+    }
+
+    @Test
+    public void testJobLabelWithCapitalLetters() {
+        config.jobLabelKeyValue = "keY1:value1,key2:value2,key3:value1";
+        config.validate(collector);
+        Assert.assertEquals(1, collector.getValidationFailures().size());
+        Assert.assertEquals("Invalid job label key 'keY1'.",
+                collector.getValidationFailures().get(0).getMessage());
+    }
+
+    @Test
+    public void testJobLabelStartingWithCapitalLetters() {
+        config.jobLabelKeyValue = "Key1:value1,key2:value2,key3:value1";
+        config.validate(collector);
+        Assert.assertEquals(1, collector.getValidationFailures().size());
+        Assert.assertEquals("Invalid job label key 'Key1'.",
+                collector.getValidationFailures().get(0).getMessage());
+    }
+
+    @Test
+    public void testJobLabelWithInvalidCharacters() {
+        config.jobLabelKeyValue = "key1:value1,key2:value2,key3:value1@";
+        config.validate(collector);
+        Assert.assertEquals(1, collector.getValidationFailures().size());
+        Assert.assertEquals("Invalid job label value 'value1@'.",
+                collector.getValidationFailures().get(0).getMessage());
+    }
+
+    @Test
+    public void testJobLabelWithEmptyKey() {
+        config.jobLabelKeyValue = ":value1,key2:value2,key3:value1";
+        config.validate(collector);
+        Assert.assertEquals(1, collector.getValidationFailures().size());
+        Assert.assertEquals("Invalid job label key ''.",
+                collector.getValidationFailures().get(0).getMessage());
+    }
+
+    @Test
+    public void testJobLabelWithEmptyValue() {
+        config.jobLabelKeyValue = "key1:,key2:value2,key3:value1";
+        config.validate(collector);
+        Assert.assertEquals(0, collector.getValidationFailures().size());
+    }
+
+    @Test
+    public void testJobLabelWithWrongFormat() {
+        config.jobLabelKeyValue = "key1=value1";
+        config.validate(collector);
+        Assert.assertEquals(1, collector.getValidationFailures().size());
+        Assert.assertEquals("Invalid job label key 'key1=value1'.",
+                collector.getValidationFailures().get(0).getMessage());
+    }
+
+    @Test
+    public void testJobLabelWithNull() {
+        config.jobLabelKeyValue = null;
+        config.validate(collector);
+        Assert.assertEquals(0, collector.getValidationFailures().size());
+    }
+
+    @Test
+    public void testJobLabelWithReservedKeys() {
+        config.jobLabelKeyValue = "job_source:value1,type:value2";
+        config.validate(collector);
+        Assert.assertEquals(2, collector.getValidationFailures().size());
+        Assert.assertEquals("Invalid job label key 'job_source'.",
+                collector.getValidationFailures().get(0).getMessage());
+    }
+
+    @Test
+    public void testJobLabelWith65Keys() {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 1; i <= 65; i++) {
+            String key = "key" + i;
+            String value = "value" + i;
+            sb.append(key).append(":").append(value).append(",");
+        }
+        // remove the last comma
+        sb.deleteCharAt(sb.length() - 1);
+        Assert.assertEquals(65, sb.toString().split(",").length);
+        config.jobLabelKeyValue = sb.toString();
+        config.validate(collector);
+        Assert.assertEquals(1, collector.getValidationFailures().size());
+        Assert.assertEquals("Number of job labels exceeds the limit.",
+                collector.getValidationFailures().get(0).getMessage());
+    }
+
+    @Test
+    public void testJobLabelWithKeyLength64() {
+        String key64 = "1234567890123456789012345678901234567890123456789012345678901234";
+        config.jobLabelKeyValue = key64 + ":value1";
+        config.validate(collector);
+        Assert.assertEquals(1, collector.getValidationFailures().size());
+        Assert.assertEquals("Invalid job label key '" + key64 + "'.",
+                collector.getValidationFailures().get(0).getMessage());
+    }
+
+    @Test
+    public void testJobLabelWithValueLength64() {
+        String value64 = "1234567890123456789012345678901234567890123456789012345678901234";
+        config.jobLabelKeyValue = "key1:" + value64;
+        config.validate(collector);
+        Assert.assertEquals(1, collector.getValidationFailures().size());
+        Assert.assertEquals("Invalid job label value '" + value64 + "'.",
+                collector.getValidationFailures().get(0).getMessage());
+    }
+
+    @Test
+    public void testJobLabelWithKeyStartingWithNumber() {
+        config.jobLabelKeyValue = "1key:value1";
+        config.validate(collector);
+        Assert.assertEquals(1, collector.getValidationFailures().size());
+        Assert.assertEquals("Invalid job label key '1key'.",
+                collector.getValidationFailures().get(0).getMessage());
+    }
+
+    @Test
+    public void testJobLabelWithKeyStartingWithDash() {
+        config.jobLabelKeyValue = "-key:value1";
+        config.validate(collector);
+        Assert.assertEquals(1, collector.getValidationFailures().size());
+        Assert.assertEquals("Invalid job label key '-key'.",
+                collector.getValidationFailures().get(0).getMessage());
+    }
+
+    @Test
+    public void testJobLabelWithKeyStartingWithHyphen() {
+        config.jobLabelKeyValue = "_key:value1";
+        config.validate(collector);
+        Assert.assertEquals(1, collector.getValidationFailures().size());
+        Assert.assertEquals("Invalid job label key '_key'.",
+                collector.getValidationFailures().get(0).getMessage());
+    }
+
+    @Test
+    public void testJobLabelWithKeyWithChineseCharacter() {
+        config.jobLabelKeyValue = "中文:value1";
+        config.validate(collector);
+        Assert.assertEquals(0, collector.getValidationFailures().size());
+    }
+
+    @Test
+    public void testJobLabelWithKeyWithJapaneseCharacter() {
+        config.jobLabelKeyValue = "日本語:value1";
+        config.validate(collector);
+        Assert.assertEquals(0, collector.getValidationFailures().size());
+    }
+
+    @Test
+    public void testJobLabelWithValueStartingWithNumber() {
+        config.jobLabelKeyValue = "key:1value";
+        config.validate(collector);
+        Assert.assertEquals(0, collector.getValidationFailures().size());
+    }
+
+    @Test
+    public void testJobLabelWithValueStartingWithDash() {
+        config.jobLabelKeyValue = "key:-value";
+        config.validate(collector);
+        Assert.assertEquals(0, collector.getValidationFailures().size());
+    }
+
+    @Test
+    public void testJobLabelWithValueStartingWithCaptialLetter() {
+        config.jobLabelKeyValue = "key:Value";
+        config.validate(collector);
+        Assert.assertEquals(1, collector.getValidationFailures().size());
+        Assert.assertEquals("Invalid job label value 'Value'.",
+                collector.getValidationFailures().get(0).getMessage());
+    }
 }

--- a/widgets/BigQueryMultiTable-batchsink.json
+++ b/widgets/BigQueryMultiTable-batchsink.json
@@ -131,10 +131,21 @@
       "label": "Advanced",
       "properties": [
         {
-          "name": "jsonStringFields",
-          "widget-type": "hidden",
-          "label": "JSON String",
-          "widget-attributes": {}
+          "name": "jobLabel",
+          "label": "BQ Job Labels",
+          "widget-type": "keyvalue",
+          "widget-attributes": {
+            "delimiter": ",",
+            "kv-delimiter": ":",
+            "key-placeholder": "Label key",
+            "value-placeholder": "Label value"
+          }
+        },
+        {
+        "name": "jsonStringFields",
+        "widget-type": "hidden",
+        "label": "JSON String",
+        "widget-attributes": {}
         },
         {
           "widget-type": "textbox",

--- a/widgets/BigQueryTable-batchsink.json
+++ b/widgets/BigQueryTable-batchsink.json
@@ -139,6 +139,17 @@
       "label": "Advanced",
       "properties": [
         {
+          "name": "jobLabels",
+          "label": "BQ Job Labels",
+          "widget-type": "keyvalue",
+          "widget-attributes": {
+            "delimiter": ",",
+            "kv-delimiter": ":",
+            "key-placeholder": "Label key",
+            "value-placeholder": "Label value"
+          }
+        },
+        {
           "name": "jsonStringFields",
           "widget-type": "csv",
           "label": "JSON String",


### PR DESCRIPTION
# Sink job label support for BQ and BQMT sink

Let's user add label to the big query sink jobs.
Labels are added as a key value pair.

## UI Field
<img width="1170" alt="image" src="https://github.com/cloudsufi/google-cloud/assets/122770897/380eab52-e457-41ac-a1fe-d8817c145984">

## UI Field (Validation)
As per big query [docs](https://cloud.google.com/bigquery/docs/adding-labels#job-label)
> Keys and values can contain only lowercase letters, numeric characters, underscores, and dashes.
> Keys must be unique.

- Reserved Keys 
> `job_source`, `type` are reserved keys and cannot be used by user.

## Code change
- Validation for UI field as per docs.
- `getJobTags` function to parse tags from csv string to a map
- updated function signature to include user defined tags

## Docs
Updated docs for the new field added to UI
> **Job Label Key Value:** Key value pairs to be added as labels to the BigQuery job. Keys must be unique.
Macro format is supported. example `key1:val1,key2:val2`

> Keys and values can contain only lowercase letters, numeric characters, underscores, and dashes.
For more information about labels, see [Labeling Jobs](https://cloud.google.com/bigquery/docs/adding-labels#job-label).

## Unit Tests

1. testJobLabelWith`CapitalLetters`
2. testJobLabelWith`InvalidCharacters`
3. testJobLabelWith`EmptyValue`
4. testJobLabelWith`DuplicateKeys`
5. testJobLabelWith`DuplicateValues`
6. testJobLabelWith`EmptyKey`
7. testJobLabelWith`Null`
8. testJobLabelWith`WrongFormat`
9. testJobLabelWith`ReservedKeys`

<img width="478" alt="image" src="https://github.com/cloudsufi/google-cloud/assets/122770897/4c73eaa1-bc9f-43bc-9c2b-1810133f0ed8">

