### PR TITLE
GCS Bugfix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
     <google.cloud.pubsub.version>1.108.1</google.cloud.pubsub.version>
     <google.cloud.spanner.version>6.10.1</google.cloud.spanner.version>
     <google.cloud.speech.version>1.24.7</google.cloud.speech.version>
-    <google.cloud.storage.version>1.118.0</google.cloud.storage.version>
+    <google.cloud.storage.version>2.3.0</google.cloud.storage.version>
     <google.cloud.datastore.version>1.105.1</google.cloud.datastore.version>
     <google.protobuf.java.version>3.19.4</google.protobuf.java.version>
     <google.tink.version>1.3.0-rc3</google.tink.version>
@@ -111,7 +111,7 @@
       <dependency>
         <groupId>com.google.apis</groupId>
         <artifactId>google-api-services-storage</artifactId>
-        <version>v1-rev20210127-1.32.1</version>
+        <version>v1-rev20211201-1.32.1</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Bug: 
Pipeline fails with warning and error for the GCS buckets with delete multi part upload policy.

Bugfix:
Plugin should support the buckets with this policy enabled in it.