### PR TITLE
Csm1365

### DIFF
--- a/docs/BigQueryTable-batchsink.md
+++ b/docs/BigQueryTable-batchsink.md
@@ -52,6 +52,13 @@ bucket will be created and then deleted after the run finishes.
 
 **GCS Upload Request Chunk Size**: GCS upload request chunk size in bytes. Default value is 8388608 bytes.
 
+**JSON String**: List of fields to be written to BigQuery as a JSON string.
+The fields must be of type STRING. To target nested fields, use dot notation.
+For example, 'name.first' will target the 'first' field in the 'name' record. (Macro Enabled)
+
+Use a comma-separated list to specify multiple fields in macro format.
+Example: "nestedObject.nestedArray.raw, nestedArray.raw".
+
 **Operation**: Type of write operation to perform. This can be set to Insert, Update or Upsert.
 * Insert - all records will be inserted in destination table.
 * Update - records that match on Table Key will be updated in the table. Records that do not match 

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySinkConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySinkConfig.java
@@ -51,6 +51,7 @@ public abstract class AbstractBigQuerySinkConfig extends BigQueryBaseConfig {
   private static final String NAME_GCS_CHUNK_SIZE = "gcsChunkSize";
   protected static final String NAME_UPDATE_SCHEMA = "allowSchemaRelaxation";
   private static final String SCHEME = "gs://";
+  protected static final String NAME_JSON_STRING_FIELDS = "jsonStringFields";
 
   @Name(Constants.Reference.REFERENCE_NAME)
   @Nullable
@@ -84,6 +85,12 @@ public abstract class AbstractBigQuerySinkConfig extends BigQueryBaseConfig {
     "This value is ignored if the dataset or temporary bucket already exist.")
   protected String location;
 
+  @Name(NAME_JSON_STRING_FIELDS)
+  @Nullable
+  @Description("Fields in input schema that should be treated as JSON strings. " +
+          "The schema of these fields should be of type STRING.")
+  protected String jsonStringFields;
+
   public AbstractBigQuerySinkConfig(BigQueryConnectorConfig connection, String dataset, String cmekKey, String bucket) {
     super(connection, dataset, cmekKey, bucket);
   }
@@ -112,6 +119,11 @@ public abstract class AbstractBigQuerySinkConfig extends BigQueryBaseConfig {
   @Nullable
   public String getGcsChunkSize() {
     return gcsChunkSize;
+  }
+
+  @Nullable
+  public String getJsonStringFields() {
+    return jsonStringFields;
   }
 
   public boolean isAllowSchemaRelaxation() {

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryJsonConverter.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryJsonConverter.java
@@ -23,12 +23,21 @@ import io.cdap.plugin.common.RecordConverter;
 
 import java.io.IOException;
 import java.util.Objects;
+import java.util.Set;
 import javax.annotation.Nullable;
 
 /**
  * BigQueryJsonConverter converts a {@link StructuredRecord} to {@link JsonObject}
  */
 public class BigQueryJsonConverter extends RecordConverter<StructuredRecord, JsonObject> {
+  private Set<String> jsonStringFieldsPaths;
+
+  public BigQueryJsonConverter() {
+  }
+
+  public BigQueryJsonConverter(Set<String> jsonStringFieldsPaths) {
+    this.jsonStringFieldsPaths = jsonStringFieldsPaths;
+  }
 
   @Override
   public JsonObject transform(StructuredRecord input, @Nullable Schema schema) throws IOException {
@@ -40,7 +49,7 @@ public class BigQueryJsonConverter extends RecordConverter<StructuredRecord, Jso
           continue;
         }
         BigQueryRecordToJson.write(writer, recordField.getName(), input.get(recordField.getName()),
-                                   recordField.getSchema());
+                                   recordField.getSchema(), jsonStringFieldsPaths);
       }
       writer.endObject();
       return writer.get().getAsJsonObject();

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryOutputFormat.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryOutputFormat.java
@@ -87,9 +87,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -121,9 +123,12 @@ public class BigQueryOutputFormat extends ForwardingBigQueryFileOutputFormat<Str
                                                                       io.cdap.cdap.api.data.schema.Schema schema)
     throws IOException, InterruptedException {
     Configuration configuration = taskAttemptContext.getConfiguration();
+    String jsonStringFields = configuration.get(BigQueryConstants.CONFIG_JSON_STRING_FIELDS, null);
+    Set<String> jsonFields = jsonStringFields == null ? Collections.emptySet() :
+            new HashSet<>(Arrays.asList(jsonStringFields.split(",")));
     return new BigQueryRecordWriter(getDelegate(configuration).getRecordWriter(taskAttemptContext),
                                     BigQueryOutputConfiguration.getFileFormat(configuration),
-                                    schema);
+                                    schema, jsonFields);
   }
 
   private io.cdap.cdap.api.data.schema.Schema getOutputSchema(Configuration configuration) throws IOException {

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryRecordWriter.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryRecordWriter.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.mapreduce.RecordWriter;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 
 import java.io.IOException;
+import java.util.Set;
 import javax.annotation.Nullable;
 
 /**
@@ -35,17 +36,20 @@ public class BigQueryRecordWriter extends RecordWriter<StructuredRecord, NullWri
   private final BigQueryFileFormat fileFormat;
   private final Schema outputSchema;
   private RecordConverter recordConverter;
+  private Set<String> jsonStringFieldsPaths;
 
-  public BigQueryRecordWriter(RecordWriter delegate, BigQueryFileFormat fileFormat, @Nullable Schema outputSchema) {
+  public BigQueryRecordWriter(RecordWriter delegate, BigQueryFileFormat fileFormat, @Nullable Schema outputSchema,
+                              Set<String> jsonStringFieldsPaths) {
     this.delegate = delegate;
     this.fileFormat = fileFormat;
     this.outputSchema = outputSchema;
+    this.jsonStringFieldsPaths = jsonStringFieldsPaths;
     initRecordConverter();
   }
 
   private void initRecordConverter() {
     if (this.fileFormat == BigQueryFileFormat.NEWLINE_DELIMITED_JSON) {
-      recordConverter = new BigQueryJsonConverter();
+      recordConverter = new BigQueryJsonConverter(jsonStringFieldsPaths);
       return;
     }
     recordConverter = new BigQueryAvroConverter();

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySink.java
@@ -109,6 +109,10 @@ public final class BigQuerySink extends AbstractBigQuerySink {
     if (schema != null) {
       validateConfiguredSchema(schema, collector);
     }
+
+    if (config.getJsonStringFields() != null && schema != null) {
+      validateJsonStringFields(schema, config.getJsonStringFields() , collector);
+    }
   }
 
   @Override
@@ -132,9 +136,12 @@ public final class BigQuerySink extends AbstractBigQuerySink {
 
     configureTable(outputSchema);
     configureBigQuerySink();
+    Table table = BigQueryUtil.getBigQueryTable(config.getDatasetProject(), config.getDataset(), config.getTable(),
+            config.getServiceAccount(), config.isServiceAccountFilePath(),
+            collector);
     initOutput(context, bigQuery, config.getReferenceName(),
                BigQueryUtil.getFQN(config.getDatasetProject(), config.getDataset(), config.getTable()),
-               config.getTable(), outputSchema, bucket, collector, null);
+               config.getTable(), outputSchema, bucket, collector, null, table);
     initSQLEngineOutput(context, bigQuery, config.getReferenceName(), context.getStageName(), config.getTable(),
                         outputSchema, collector);
   }

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkUtils.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkUtils.java
@@ -77,6 +77,7 @@ public final class BigQuerySinkUtils {
   private static final String TEMPORARY_BUCKET_FORMAT = GS_PATH_FORMAT + "/input/%s-%s";
   private static final String DATETIME = "DATETIME";
   private static final String RECORD = "RECORD";
+  private static final String JSON = "JSON";
   private static final Gson GSON = new Gson();
   private static final Type LIST_OF_FIELD_TYPE = new TypeToken<ArrayList<Field>>() {
   }.getType();
@@ -279,6 +280,34 @@ public final class BigQuerySinkUtils {
     baseConfiguration.setBoolean("fs.gs.metadata.cache.enable", false);
     return bucket;
   }
+  /**
+   * Sets string fields to JSON type if they are present in the provided list of fields.
+   * @param fields list of BigQuery table fields.
+   * @param jsonStringFields Comma separated list of fields that should be set to JSON type.
+   *
+   */
+  public static void setJsonStringFields(List<BigQueryTableFieldSchema> fields,
+                                                                   String jsonStringFields) {
+    Set<String> jsonFields = new HashSet<>(Arrays.asList(jsonStringFields.split(",")));
+    setJsonStringFields(fields, jsonFields, new ArrayList<>());
+  }
+
+  private static void setJsonStringFields(List<BigQueryTableFieldSchema> fields, Set<String> jsonFields,
+                                             List<String> path) {
+    for (BigQueryTableFieldSchema field : fields) {
+      String fieldName = field.getName();
+      String fieldType = field.getType();
+      String separator = path.isEmpty() ? "" : ".";
+      String fieldPath = String.join(".", path) + separator + fieldName;
+      if (jsonFields.contains(fieldPath) && fieldType.equals(LegacySQLTypeName.STRING.name())) {
+        field.setType(LegacySQLTypeName.valueOf(JSON).name());
+      } else if (field.getType().equals(LegacySQLTypeName.RECORD.name())) {
+        path.add(fieldName);
+        setJsonStringFields(field.getFields(), jsonFields, path);
+        path.remove(path.size() - 1);
+      }
+    }
+  }
 
   /**
    * Configures output for Sink
@@ -299,6 +328,10 @@ public final class BigQuerySinkUtils {
     // Set up table schema
     BigQueryTableSchema outputTableSchema = new BigQueryTableSchema();
     if (!fields.isEmpty()) {
+      String jsonStringFields = configuration.get(BigQueryConstants.CONFIG_JSON_STRING_FIELDS, null);
+      if (jsonStringFields != null) {
+        setJsonStringFields(fields, jsonStringFields);
+      }
       outputTableSchema.setFields(fields);
     }
 
@@ -919,4 +952,26 @@ public final class BigQuerySinkUtils {
     }
   }
 
+  /**
+   * Get the list of fields that are of type JSON from the BigQuery schema.
+   * @param bqSchema BigQuery schema.
+   * @return comma separated list of fields that are of type JSON.
+   */
+  public static String getJsonStringFieldsFromBQSchema(com.google.cloud.bigquery.Schema bqSchema) {
+    ArrayList<String> fields = new ArrayList<>();
+    getJsonStringFieldsFromBQSchema(bqSchema.getFields(), fields, new ArrayList<>());
+    return String.join(",", fields);
+  }
+  private static void getJsonStringFieldsFromBQSchema(FieldList fieldList,
+                                                      ArrayList<String> fields, ArrayList<String> path) {
+    for (Field field : fieldList) {
+      path.add(field.getName());
+      if (field.getType() == LegacySQLTypeName.RECORD) {
+        getJsonStringFieldsFromBQSchema(field.getSubFields(), fields, path);
+      } else if (field.getType().equals(LegacySQLTypeName.valueOf(JSON))) {
+        fields.add(String.join(".", path));
+      }
+      path.remove(path.size() - 1);
+    }
+  }
 }

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryConstants.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryConstants.java
@@ -34,6 +34,7 @@ public interface BigQueryConstants {
   String CONFIG_TABLE_KEY = "cdap.bq.sink.table.key";
   String CONFIG_DEDUPE_BY = "cdap.bq.sink.dedupe.by";
   String CONFIG_TABLE_FIELDS = "cdap.bq.sink.table.fields";
+  String CONFIG_JSON_STRING_FIELDS = "cdap.bq.sink.json.string.fields";
   String CONFIG_FILTER = "cdap.bq.source.filter";
   String CONFIG_PARTITION_FILTER = "cdap.bq.sink.partition.filter";
   String CONFIG_JOB_ID = "cdap.bq.sink.job.id";

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryUtil.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryUtil.java
@@ -113,7 +113,8 @@ public final class BigQueryUtil {
     Set<LegacySQLTypeName>>builder()
     .put(Schema.Type.INT, ImmutableSet.of(LegacySQLTypeName.INTEGER))
     .put(Schema.Type.LONG, ImmutableSet.of(LegacySQLTypeName.INTEGER))
-    .put(Schema.Type.STRING, ImmutableSet.of(LegacySQLTypeName.STRING, LegacySQLTypeName.DATETIME))
+    .put(Schema.Type.STRING, ImmutableSet.of(LegacySQLTypeName.STRING, LegacySQLTypeName.DATETIME,
+            LegacySQLTypeName.valueOf("JSON")))
     .put(Schema.Type.FLOAT, ImmutableSet.of(LegacySQLTypeName.FLOAT))
     .put(Schema.Type.DOUBLE, ImmutableSet.of(LegacySQLTypeName.FLOAT))
     .put(Schema.Type.BOOLEAN, ImmutableSet.of(LegacySQLTypeName.BOOLEAN))

--- a/src/test/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySinkTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySinkTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.gcp.bigquery.sink;
+
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.etl.mock.validation.MockFailureCollector;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for {@link AbstractBigQuerySink}.
+ */
+public class AbstractBigQuerySinkTest {
+  MockFailureCollector collector;
+  Schema notNestedSchema;
+  Schema nestedSchema;
+  Schema oneLevelNestedSchema;
+
+  @Before
+  public void setup() throws NoSuchMethodException {
+    collector = new MockFailureCollector();
+    notNestedSchema = Schema.recordOf("test",
+            Schema.Field.of("id", Schema.of(Schema.Type.INT)),
+            Schema.Field.of("name", Schema.of(Schema.Type.STRING)),
+            Schema.Field.of("age", Schema.of(Schema.Type.INT)),
+            Schema.Field.of("objectJson", Schema.of(Schema.Type.STRING)));
+    nestedSchema = Schema.recordOf("nestedObject",
+            Schema.Field.of("nestedId", Schema.of(Schema.Type.INT)),
+            Schema.Field.of("nestedName", Schema.of(Schema.Type.STRING)),
+            Schema.Field.of("nestedAge", Schema.of(Schema.Type.INT)),
+            Schema.Field.of("nestedObjectJson", Schema.of(Schema.Type.STRING)));
+    oneLevelNestedSchema = Schema.recordOf("test",
+            Schema.Field.of("id", Schema.of(Schema.Type.INT)),
+            Schema.Field.of("name", Schema.of(Schema.Type.STRING)),
+            Schema.Field.of("age", Schema.of(Schema.Type.INT)),
+            Schema.Field.of("nested", nestedSchema));
+  }
+
+  @Test
+  public void testValidateJsonStringFieldsNoNesting() {
+    String jsonFields = "objectJson";
+    new BigQuerySink(null).validateJsonStringFields(notNestedSchema, jsonFields, collector);
+    Assert.assertEquals(0, collector.getValidationFailures().size());
+  }
+
+  @Test
+  public void testValidateJsonStringFieldsOneLevelNesting() {
+    String jsonFields = "nested.nestedObjectJson";
+    new BigQuerySink(null).validateJsonStringFields(oneLevelNestedSchema, jsonFields, collector);
+    Assert.assertEquals(0, collector.getValidationFailures().size());
+
+  }
+
+  @Test
+  public void testValidateJsonStringFieldsOneLevelNestingNotString() {
+
+    String jsonFields = "nested.nestedId";
+    new BigQuerySink(null).validateJsonStringFields(oneLevelNestedSchema, jsonFields, collector);
+    Assert.assertEquals(String.format(
+                    "Field '%s' is of type '%s' which is not supported for conversion to JSON string.",
+                    "nested.nestedId", Schema.Type.INT),
+            collector.getValidationFailures().stream().findFirst().get().getMessage());
+
+  }
+
+  @Test
+  public void testValidateJsonStringFieldsDoesNotExist() {
+    String jsonFields = "nested.nestedObjectJson";
+    new BigQuerySink(null).validateJsonStringFields(notNestedSchema, jsonFields, collector);
+    Assert.assertEquals(String.format("Field(s) '%s' are not present in the Output Schema.", "nested.nestedObjectJson"),
+            collector.getValidationFailures().stream().findFirst().get().getMessage());
+  }
+
+}

--- a/widgets/BigQueryMultiTable-batchsink.json
+++ b/widgets/BigQueryMultiTable-batchsink.json
@@ -131,6 +131,12 @@
       "label": "Advanced",
       "properties": [
         {
+          "name": "jsonStringFields",
+          "widget-type": "hidden",
+          "label": "JSON String",
+          "widget-attributes": {}
+        },
+        {
           "widget-type": "textbox",
           "label": "Temporary Bucket Name",
           "name": "bucket",

--- a/widgets/BigQueryTable-batchsink.json
+++ b/widgets/BigQueryTable-batchsink.json
@@ -139,6 +139,12 @@
       "label": "Advanced",
       "properties": [
         {
+          "name": "jsonStringFields",
+          "widget-type": "csv",
+          "label": "JSON String",
+          "widget-attributes": {}
+        },
+        {
           "widget-type": "radio-group",
           "name": "operation",
           "label": "Operation",


### PR DESCRIPTION
## BQ Sink Json Support

BigQuery has json as data type and this pr adds support in the sink plugin for it.

### JSON String

As there is no json data type in cdap we are using string as json , to differentiate  string and json we let user enter all the strings that are to be treated as json via a UI field

![image](https://github.com/cloudsufi/google-cloud/assets/122770897/029d987d-8a74-4d24-b53c-6ef73e4f36d7)


### Nested Fields

Nested Fields can be targeted via the `.` as shown in the image above

![image](https://github.com/cloudsufi/google-cloud/assets/122770897/a29b3a8b-6cf0-4b8d-a897-e3a23dcd132c)


### Code Changes

- User may skip adding the fields if table already exist. 
`getJsonStringFieldsFromBQSchema` Function can extract the json fields from the tabel schema

- `setJsonStringFields` Updates the table schema for the api request , marking user selected string fields to json

- `validateJsonStringFields` Validated if all fields given by user are present in schema

- We need fields at runtime hence they are set in config with a key.

`writeJsonObjectToWriter`
`writeJsonElementToWriter`
`writeJsonArrayToWriter`
`writeJsonPrimitiveToWriter`

All function are used to merge the user json in the main tree as json element.

### Note
Some function may be repeated , this is done to maintain a path and call them recursively for nested fields.


