### PR TITLE
[PLUGIN-1803] Add validation for logical type (array/repeated)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -540,6 +540,10 @@
           <artifactId>slf4j-api</artifactId>
           <groupId>org.slf4j</groupId>
         </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-reload4j</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -567,6 +571,10 @@
         <exclusion>
           <groupId>org.apache.hadoop</groupId>
           <artifactId>hadoop-yarn-client</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-reload4j</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/action/BigQueryArgumentSetter.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/action/BigQueryArgumentSetter.java
@@ -80,7 +80,7 @@ public final class BigQueryArgumentSetter extends AbstractBigQueryAction {
     Credentials credentials = config.getServiceAccount() == null ?
       null : GCPUtils.loadServiceAccountCredentials(config.getServiceAccount(),
                                                     config.isServiceAccountFilePath());
-    BigQuery bigQuery = GCPUtils.getBigQuery(config.getProject(), credentials);
+    BigQuery bigQuery = GCPUtils.getBigQuery(config.getProject(), credentials, null);
     Job queryJob = bigQuery.create(JobInfo.newBuilder(queryConfig).setJobId(jobId).build());
 
     LOG.info("Executing SQL as job {}.", jobId.getJob());

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/common/BigQueryBaseConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/common/BigQueryBaseConfig.java
@@ -213,7 +213,7 @@ public class BigQueryBaseConfig extends PluginConfig {
         DatasetId datasetId = DatasetId.of(datasetProjectId, datasetName);
         TableId tableId = tableName == null ? null : TableId.of(datasetProjectId, datasetName, tableName);
         Credentials credentials = connection.getCredentials(failureCollector);
-        BigQuery bigQuery = GCPUtils.getBigQuery(connection.getProject(), credentials);
+        BigQuery bigQuery = GCPUtils.getBigQuery(connection.getProject(), credentials, null);
         Storage storage = GCPUtils.getStorage(connection.getProject(), credentials);
         if (bigQuery == null || storage == null) {
             return;

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/connector/BigQueryConnector.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/connector/BigQueryConnector.java
@@ -132,7 +132,7 @@ public final class BigQueryConnector implements DirectConnector {
     }
 
     try {
-      BigQuery bigQuery = GCPUtils.getBigQuery(config.getDatasetProject(), credentials);
+      BigQuery bigQuery = GCPUtils.getBigQuery(config.getDatasetProject(), credentials, null);
       bigQuery.listDatasets(BigQuery.DatasetListOption.pageSize(1));
     } catch (Exception e) {
       failureCollector.addFailure(String.format("Could not connect to BigQuery: %s", e.getMessage()),
@@ -236,7 +236,7 @@ public final class BigQueryConnector implements DirectConnector {
         GCPUtils.loadServiceAccountCredentials(config.getServiceAccount(), config.isServiceAccountFilePath());
     }
     // Here project decides where the BQ job is run and under which the datasets is listed
-    return GCPUtils.getBigQuery(project, credentials);
+    return GCPUtils.getBigQuery(project, credentials, null);
   }
 
   /**

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySink.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/AbstractBigQuerySink.java
@@ -88,7 +88,7 @@ public abstract class AbstractBigQuerySink extends BatchSink<StructuredRecord, S
     Credentials credentials = serviceAccount == null ?
       null : GCPUtils.loadServiceAccountCredentials(serviceAccount, config.isServiceAccountFilePath());
     String project = config.getProject();
-    bigQuery = GCPUtils.getBigQuery(project, credentials);
+    bigQuery = GCPUtils.getBigQuery(project, credentials, null);
     FailureCollector collector = context.getFailureCollector();
     CryptoKeyName cmekKeyName = CmekUtils.getCmekKey(config.cmekKey, context.getArguments().asMap(), collector);
     collector.getOrThrowException();

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryOutputFormat.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryOutputFormat.java
@@ -810,6 +810,6 @@ public class BigQueryOutputFormat extends ForwardingBigQueryFileOutputFormat<Str
     String projectId = ConfigurationUtil.getMandatoryConfig(config,
         BigQueryConfiguration.PROJECT_ID);
     Credentials credentials = GCPUtils.loadCredentialsFromConf(config);
-    return GCPUtils.getBigQuery(projectId, credentials);
+    return GCPUtils.getBigQuery(projectId, credentials, null);
   }
 }

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/source/BigQuerySource.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/source/BigQuerySource.java
@@ -136,7 +136,7 @@ public final class BigQuerySource extends BatchSource<LongWritable, GenericData.
     // Create BigQuery client
     String serviceAccount = config.getServiceAccount();
     Credentials credentials = BigQuerySourceUtils.getCredentials(config.getConnection());
-    BigQuery bigQuery = GCPUtils.getBigQuery(config.getProject(), credentials);
+    BigQuery bigQuery = GCPUtils.getBigQuery(config.getProject(), credentials, null);
     Dataset dataset = bigQuery.getDataset(DatasetId.of(config.getDatasetProject(), config.getDataset()));
     Storage storage = GCPUtils.getStorage(config.getProject(), credentials);
 

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/source/BigQuerySourceConfig.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/source/BigQuerySourceConfig.java
@@ -186,7 +186,7 @@ public final class BigQuerySourceConfig extends BigQueryBaseConfig {
     }
     DatasetId datasetId = DatasetId.of(getDatasetProject(), getDataset());
     Credentials credentials = connection.getCredentials(collector);
-    BigQuery bigQuery = GCPUtils.getBigQuery(getProject(), credentials);
+    BigQuery bigQuery = GCPUtils.getBigQuery(getProject(), credentials, null);
     if (bigQuery == null) {
       return;
     }

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/source/BigQuerySourceUtils.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/source/BigQuerySourceUtils.java
@@ -171,7 +171,7 @@ public class BigQuerySourceUtils {
     String temporaryTable = configuration.get(BigQueryConstants.CONFIG_TEMPORARY_TABLE_NAME);
     try {
       Credentials credentials = getCredentials(config.getConnection());
-      BigQuery bigQuery = GCPUtils.getBigQuery(config.getProject(), credentials);
+      BigQuery bigQuery = GCPUtils.getBigQuery(config.getProject(), credentials, null);
       bigQuery.delete(TableId.of(config.getDatasetProject(), config.getDataset(), temporaryTable));
       LOG.debug("Deleted temporary table '{}'", temporaryTable);
     } catch (IOException e) {

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/sqlengine/BigQuerySQLEngine.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/sqlengine/BigQuerySQLEngine.java
@@ -156,7 +156,7 @@ public class BigQuerySQLEngine
     datasetName = sqlEngineConfig.getDataset();
 
     // Initialize BQ and GCS clients.
-    bigQuery = GCPUtils.getBigQuery(project, credentials);
+    bigQuery = GCPUtils.getBigQuery(project, credentials, null);
     storage = GCPUtils.getStorage(project, credentials);
     Dataset dataset = bigQuery.getDataset(DatasetId.of(datasetProject, datasetName));
     bucket = BigQueryUtil.getStagingBucketName(context.getRuntimeArguments(), sqlEngineConfig.getLocation(),

--- a/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryUtil.java
+++ b/src/main/java/io/cdap/plugin/gcp/bigquery/util/BigQueryUtil.java
@@ -581,7 +581,7 @@ public final class BigQueryUtil {
           "serviceFilePath");
       }
     }
-    BigQuery bigQuery = GCPUtils.getBigQuery(datasetProject, credentials);
+    BigQuery bigQuery = GCPUtils.getBigQuery(datasetProject, credentials, null);
 
     Table table;
     try {
@@ -636,7 +636,7 @@ public final class BigQueryUtil {
         throw collector.getOrThrowException();
       }
     }
-    BigQuery bigQuery = GCPUtils.getBigQuery(projectId, credentials);
+    BigQuery bigQuery = GCPUtils.getBigQuery(projectId, credentials, null);
 
     Table table = null;
     try {

--- a/src/main/java/io/cdap/plugin/gcp/common/GCPUtils.java
+++ b/src/main/java/io/cdap/plugin/gcp/common/GCPUtils.java
@@ -28,6 +28,7 @@ import com.google.cloud.hadoop.fs.gcs.GoogleHadoopFS;
 import com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem;
 import com.google.cloud.hadoop.util.CredentialFactory;
 import com.google.cloud.hadoop.util.HadoopCredentialConfiguration;
+import com.google.cloud.http.HttpTransportOptions;
 import com.google.cloud.kms.v1.CryptoKeyName;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.Storage;
@@ -77,6 +78,7 @@ public class GCPUtils {
   public static final List<String> BIGQUERY_SCOPES = Arrays.asList("https://www.googleapis.com/auth/drive",
                                                                    "https://www.googleapis.com/auth/bigquery");
   public static final String FQN_RESERVED_CHARACTERS_PATTERN = ".*[.:` \t\n].*";
+  public static final int MILLISECONDS_MULTIPLIER = 1000;
 
   /**
    * Load a service account from the local file system.
@@ -233,7 +235,7 @@ public class GCPUtils {
     return properties;
   }
 
-  public static BigQuery getBigQuery(String project, @Nullable Credentials credentials) {
+  public static BigQuery getBigQuery(String project, @Nullable Credentials credentials, @Nullable Integer readTimeout) {
     BigQueryOptions.Builder bigqueryBuilder = BigQueryOptions.newBuilder().setProjectId(project);
     if (credentials != null) {
       Set<String> scopes = new HashSet<>(BIGQUERY_SCOPES);
@@ -252,6 +254,12 @@ public class GCPUtils {
       }
       bigqueryBuilder.setCredentials(credentials);
     }
+
+    if (readTimeout != null) {
+      bigqueryBuilder.setTransportOptions(HttpTransportOptions.newBuilder()
+          .setReadTimeout(readTimeout * MILLISECONDS_MULTIPLIER).build());
+    }
+
     return bigqueryBuilder.build().getService();
   }
 

--- a/src/main/java/io/cdap/plugin/gcp/dataplex/sink/DataplexBatchSink.java
+++ b/src/main/java/io/cdap/plugin/gcp/dataplex/sink/DataplexBatchSink.java
@@ -285,7 +285,7 @@ public final class DataplexBatchSink extends BatchSink<StructuredRecord, Object,
     String[] assetValues = asset.getResourceSpec().getName().split("/");
     String datasetName = assetValues[assetValues.length - 1];
     String datasetProject = assetValues[assetValues.length - 3];
-    bigQuery = GCPUtils.getBigQuery(datasetProject, credentials);
+    bigQuery = GCPUtils.getBigQuery(datasetProject, credentials, null);
     // Get required dataset ID and dataset instance (if it exists)
     DatasetId datasetId = DatasetId.of(datasetProject, datasetName);
     Dataset dataset = bigQuery.getDataset(datasetId);

--- a/src/main/java/io/cdap/plugin/gcp/dataplex/source/DataplexBatchSource.java
+++ b/src/main/java/io/cdap/plugin/gcp/dataplex/source/DataplexBatchSource.java
@@ -217,7 +217,7 @@ public class DataplexBatchSource extends BatchSource<Object, Object, StructuredR
     // Create BigQuery client
     String serviceAccount = config.getServiceAccount();
     Credentials credentials = config.getCredentials(collector);
-    BigQuery bigQuery = GCPUtils.getBigQuery(datasetProject, credentials);
+    BigQuery bigQuery = GCPUtils.getBigQuery(datasetProject, credentials, null);
 
     // Temporary bucket path without BQ template
     bucketPath = UUID.randomUUID().toString();
@@ -382,7 +382,7 @@ public class DataplexBatchSource extends BatchSource<Object, Object, StructuredR
       BigQuerySourceUtils.deleteGcsTemporaryDirectory(configuration, null, bucketPath);
       String temporaryTable = configuration.get(CONFIG_TEMPORARY_TABLE_NAME);
       Credentials credentials = config.getCredentials(context.getFailureCollector());
-      BigQuery bigQuery = GCPUtils.getBigQuery(config.getProject(), credentials);
+      BigQuery bigQuery = GCPUtils.getBigQuery(config.getProject(), credentials, null);
       bigQuery.delete(TableId.of(datasetProject, dataset, temporaryTable));
       LOG.debug("Deleted temporary table '{}'", temporaryTable);
     } else {

--- a/src/test/java/io/cdap/plugin/gcp/bigquery/action/BigQueryExecuteCmekKeyTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/bigquery/action/BigQueryExecuteCmekKeyTest.java
@@ -82,7 +82,7 @@ public class BigQueryExecuteCmekKeyTest {
     serviceAccountKey = new String(Files.readAllBytes(Paths.get(new File(serviceAccountFilePath).getAbsolutePath())),
                                    StandardCharsets.UTF_8);
     Credentials credentials = GCPUtils.loadServiceAccountCredentials(serviceAccountKey, false);
-    bigQuery = GCPUtils.getBigQuery(project, credentials);
+    bigQuery = GCPUtils.getBigQuery(project, credentials, null);
   }
 
   private BigQueryExecute.Config.Builder getBuilder() throws NoSuchFieldException {

--- a/src/test/java/io/cdap/plugin/gcp/bigquery/action/BigQueryExecuteTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/bigquery/action/BigQueryExecuteTest.java
@@ -135,7 +135,8 @@ public class BigQueryExecuteTest {
             BigQueryExecute.Config.DEFAULT_INITIAL_RETRY_DURATION_SECONDS,
             BigQueryExecute.Config.DEFULT_MAX_RETRY_DURATION_SECONDS,
             BigQueryExecute.Config.DEFAULT_MAX_RETRY_COUNT,
-            BigQueryExecute.Config.DEFAULT_RETRY_MULTIPLIER);
+            BigQueryExecute.Config.DEFAULT_RETRY_MULTIPLIER,
+            BigQueryExecute.Config.DEFAULT_READ_TIMEOUT);
     Assert.assertEquals(0, failureCollector.getValidationFailures().size());
   }
 
@@ -144,7 +145,8 @@ public class BigQueryExecuteTest {
     config.validateRetryConfiguration(failureCollector, -1L,
             BigQueryExecute.Config.DEFULT_MAX_RETRY_DURATION_SECONDS,
             BigQueryExecute.Config.DEFAULT_MAX_RETRY_COUNT,
-            BigQueryExecute.Config.DEFAULT_RETRY_MULTIPLIER);
+            BigQueryExecute.Config.DEFAULT_RETRY_MULTIPLIER,
+            BigQueryExecute.Config.DEFAULT_READ_TIMEOUT);
     Assert.assertEquals(1, failureCollector.getValidationFailures().size());
     Assert.assertEquals("Initial retry duration must be greater than 0.",
             failureCollector.getValidationFailures().get(0).getMessage());
@@ -155,7 +157,8 @@ public class BigQueryExecuteTest {
     config.validateRetryConfiguration(failureCollector,
             BigQueryExecute.Config.DEFAULT_INITIAL_RETRY_DURATION_SECONDS, -1L,
             BigQueryExecute.Config.DEFAULT_MAX_RETRY_COUNT,
-            BigQueryExecute.Config.DEFAULT_RETRY_MULTIPLIER);
+            BigQueryExecute.Config.DEFAULT_RETRY_MULTIPLIER,
+            BigQueryExecute.Config.DEFAULT_READ_TIMEOUT);
     Assert.assertEquals(2, failureCollector.getValidationFailures().size());
     Assert.assertEquals("Max retry duration must be greater than 0.",
             failureCollector.getValidationFailures().get(0).getMessage());
@@ -168,7 +171,8 @@ public class BigQueryExecuteTest {
     config.validateRetryConfiguration(failureCollector,
             BigQueryExecute.Config.DEFAULT_INITIAL_RETRY_DURATION_SECONDS,
             BigQueryExecute.Config.DEFULT_MAX_RETRY_DURATION_SECONDS,
-            BigQueryExecute.Config.DEFAULT_MAX_RETRY_COUNT, -1.0);
+            BigQueryExecute.Config.DEFAULT_MAX_RETRY_COUNT, -1.0,
+            BigQueryExecute.Config.DEFAULT_READ_TIMEOUT);
     Assert.assertEquals(1, failureCollector.getValidationFailures().size());
     Assert.assertEquals("Retry multiplier must be strictly greater than 1.",
             failureCollector.getValidationFailures().get(0).getMessage());
@@ -179,7 +183,8 @@ public class BigQueryExecuteTest {
     config.validateRetryConfiguration(failureCollector,
             BigQueryExecute.Config.DEFAULT_INITIAL_RETRY_DURATION_SECONDS,
             BigQueryExecute.Config.DEFULT_MAX_RETRY_DURATION_SECONDS, -1,
-            BigQueryExecute.Config.DEFAULT_RETRY_MULTIPLIER);
+            BigQueryExecute.Config.DEFAULT_RETRY_MULTIPLIER,
+            BigQueryExecute.Config.DEFAULT_READ_TIMEOUT);
     Assert.assertEquals(1, failureCollector.getValidationFailures().size());
     Assert.assertEquals("Max retry count must be greater than 0.",
             failureCollector.getValidationFailures().get(0).getMessage());
@@ -190,7 +195,8 @@ public class BigQueryExecuteTest {
     config.validateRetryConfiguration(failureCollector,
             BigQueryExecute.Config.DEFAULT_INITIAL_RETRY_DURATION_SECONDS,
             BigQueryExecute.Config.DEFULT_MAX_RETRY_DURATION_SECONDS,
-            BigQueryExecute.Config.DEFAULT_MAX_RETRY_COUNT, 1.0);
+            BigQueryExecute.Config.DEFAULT_MAX_RETRY_COUNT, 1.0,
+            BigQueryExecute.Config.DEFAULT_READ_TIMEOUT);
     Assert.assertEquals(1, failureCollector.getValidationFailures().size());
     Assert.assertEquals("Retry multiplier must be strictly greater than 1.",
             failureCollector.getValidationFailures().get(0).getMessage());
@@ -200,9 +206,23 @@ public class BigQueryExecuteTest {
   public void testValidateRetryConfigurationWithMaxRetryLessThanInitialRetry() {
     config.validateRetryConfiguration(failureCollector, 10L, 5L,
             BigQueryExecute.Config.DEFAULT_MAX_RETRY_COUNT,
-            BigQueryExecute.Config.DEFAULT_RETRY_MULTIPLIER);
+            BigQueryExecute.Config.DEFAULT_RETRY_MULTIPLIER,
+            BigQueryExecute.Config.DEFAULT_READ_TIMEOUT);
     Assert.assertEquals(1, failureCollector.getValidationFailures().size());
     Assert.assertEquals("Max retry duration must be greater than initial retry duration.",
+            failureCollector.getValidationFailures().get(0).getMessage());
+  }
+
+  @Test
+  public void testValidateRetryConfigurationWithInvalidReadTimeout() {
+    config.validateRetryConfiguration(failureCollector,
+            BigQueryExecute.Config.DEFAULT_INITIAL_RETRY_DURATION_SECONDS,
+            BigQueryExecute.Config.DEFULT_MAX_RETRY_DURATION_SECONDS,
+            BigQueryExecute.Config.DEFAULT_MAX_RETRY_COUNT,
+            BigQueryExecute.Config.DEFAULT_RETRY_MULTIPLIER,
+            -1);
+    Assert.assertEquals(1, failureCollector.getValidationFailures().size());
+    Assert.assertEquals("Read timeout must be greater than 0.",
             failureCollector.getValidationFailures().get(0).getMessage());
   }
 

--- a/src/test/java/io/cdap/plugin/gcp/bigquery/connector/BigQueryConnectorTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/bigquery/connector/BigQueryConnectorTest.java
@@ -95,7 +95,7 @@ public class BigQueryConnectorTest {
     table = "users";
 
     // create dataset, table, and populate table
-    bigQuery = GCPUtils.getBigQuery(project, testEnvironment.getCredentials());
+    bigQuery = GCPUtils.getBigQuery(project, testEnvironment.getCredentials(), null);
     bigQuery.create(DatasetInfo.of(DatasetId.of(project, dataset)));
 
     // TODO: (CDAP-19477) test one of the fields being required instead of nullable

--- a/src/test/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkCmekKeyTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkCmekKeyTest.java
@@ -87,7 +87,7 @@ public class BigQuerySinkCmekKeyTest {
                                    StandardCharsets.UTF_8);
     Credentials credentials = GCPUtils.loadServiceAccountCredentials(serviceAccountKey, false);
     storage = GCPUtils.getStorage(project, credentials);
-    bigQuery = GCPUtils.getBigQuery(project, credentials);
+    bigQuery = GCPUtils.getBigQuery(project, credentials, null);
   }
 
   private BigQuerySinkConfig.Builder getBuilder() {

--- a/src/test/java/io/cdap/plugin/gcp/bigquery/source/BigQuerySourceCmekKeyTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/bigquery/source/BigQuerySourceCmekKeyTest.java
@@ -93,7 +93,7 @@ public class BigQuerySourceCmekKeyTest {
                                    StandardCharsets.UTF_8);
     Credentials credentials = GCPUtils.loadServiceAccountCredentials(serviceAccountKey, false);
     storage = GCPUtils.getStorage(project, credentials);
-    bigQuery = GCPUtils.getBigQuery(project, credentials);
+    bigQuery = GCPUtils.getBigQuery(project, credentials, null);
   }
 
   @Before

--- a/src/test/java/io/cdap/plugin/gcp/bigquery/sqlengine/BigQuerySQLEngineCmekKeyTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/bigquery/sqlengine/BigQuerySQLEngineCmekKeyTest.java
@@ -81,7 +81,7 @@ public class BigQuerySQLEngineCmekKeyTest {
                                    StandardCharsets.UTF_8);
     Credentials credentials = GCPUtils.loadServiceAccountCredentials(serviceAccountKey, false);
     storage = GCPUtils.getStorage(project, credentials);
-    bigQuery = GCPUtils.getBigQuery(project, credentials);
+    bigQuery = GCPUtils.getBigQuery(project, credentials, null);
   }
 
   private BigQuerySQLEngineConfig.Builder getBuilder() {

--- a/src/test/java/io/cdap/plugin/gcp/dataplex/sink/config/DataplexBatchSinkTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/dataplex/sink/config/DataplexBatchSinkTest.java
@@ -278,7 +278,7 @@ public class DataplexBatchSinkTest {
 
     PowerMockito.mockStatic(GCPUtils.class);
     BigQuery bigQuery = Mockito.mock(BigQuery.class);
-    Mockito.when(GCPUtils.getBigQuery("datasetProjectName", googleCredentials)).thenReturn(bigQuery);
+    Mockito.when(GCPUtils.getBigQuery("datasetProjectName", googleCredentials, null)).thenReturn(bigQuery);
     List<BigQueryTableFieldSchema> fields = new ArrayList<>();
     BigQueryTableFieldSchema bigQueryTableFieldSchema = new BigQueryTableFieldSchema();
     fields.add(bigQueryTableFieldSchema);

--- a/src/test/java/io/cdap/plugin/gcp/dataplex/source/DataplexBatchSourceTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/dataplex/source/DataplexBatchSourceTest.java
@@ -254,7 +254,7 @@ public class DataplexBatchSourceTest {
     BigQuery bigQuery = Mockito.mock(BigQuery.class);
     PowerMockito.mockStatic(GCPUtils.class);
     Storage storage = Mockito.mock(Storage.class);
-    Mockito.when(GCPUtils.getBigQuery("dataset", googleCredentials)).thenReturn(bigQuery);
+    Mockito.when(GCPUtils.getBigQuery("dataset", googleCredentials, null)).thenReturn(bigQuery);
     PowerMockito.when(BigQueryUtil.getBigQueryConfig(null, null, null,
       "account")).thenReturn(configuration);
     Dataset dataset = Mockito.mock(Dataset.class);
@@ -353,7 +353,7 @@ public class DataplexBatchSourceTest {
     PowerMockito.mockStatic(GCPUtils.class);
     Map<String, String> map = new HashMap<>();
     map.put("price", "100");
-    Mockito.when(GCPUtils.getBigQuery("dataset", googleCredentials)).thenReturn(bigQuery);
+    Mockito.when(GCPUtils.getBigQuery("dataset", googleCredentials, null)).thenReturn(bigQuery);
     PowerMockito.mockStatic(ConfigurationUtils.class);
     Mockito.when(ConfigurationUtils.getNonDefaultConfigurations(configuration)).thenReturn(map);
     PowerMockito.when(BigQueryUtil.getBigQueryConfig(null, null, null,
@@ -377,7 +377,7 @@ public class DataplexBatchSourceTest {
     
     dataplexBatchSource.initialize(runtimeContext);
     dataplexBatchSource.prepareRun(context);
-    Mockito.when(GCPUtils.getBigQuery(null, googleCredentials)).thenReturn(bigQuery);
+    Mockito.when(GCPUtils.getBigQuery(null, googleCredentials, null)).thenReturn(bigQuery);
     dataplexBatchSource.onRunFinish(true, context);
     Assert.assertEquals(0, mockFailureCollector.getValidationFailures().size());
   }

--- a/src/test/java/io/cdap/plugin/gcp/spanner/connector/SpannerConnectorTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/spanner/connector/SpannerConnectorTest.java
@@ -196,43 +196,34 @@ public class SpannerConnectorTest {
     // browse project
     BrowseDetail detail = connector.browse(new MockConnectorContext(new MockConnectorConfigurer()),
                                            BrowseRequest.builder("/").build());
-    BrowseDetail expected = BrowseDetail.builder()
-      .setTotalCount(1)
-      .addEntity(BrowseEntity.builder(instance, "/" + instance, "instance")
+    BrowseEntity expected = BrowseEntity.builder(instance, "/" + instance, "instance")
                    .canBrowse(true)
                    .canSample(false)
-                   .build())
-      .build();
-    Assert.assertEquals(expected, detail);
+                   .build();
+    Assert.assertTrue(detail.getEntities().contains(expected));
 
     // browse instance
     detail = connector.browse(new MockConnectorContext(new MockConnectorConfigurer()),
                               BrowseRequest.builder(instance).build());
-    expected = BrowseDetail.builder()
-      .setTotalCount(1)
-      .addEntity(BrowseEntity.builder(database, String.format("/%s/%s", instance, database), "database")
+    expected = BrowseEntity.builder(database, String.format("/%s/%s", instance, database), "database")
                    .canBrowse(true)
                    .canSample(false)
-                   .build())
-      .build();
-    Assert.assertEquals(expected, detail);
+                   .build();
+    Assert.assertTrue(detail.getEntities().contains(expected));
 
     // browse database
     detail = connector.browse(new MockConnectorContext(new MockConnectorConfigurer()),
                               BrowseRequest.builder(instance + "/" + database).build());
-    expected = BrowseDetail.builder()
-      .setTotalCount(1)
-      .addEntity(BrowseEntity.builder(table, String.format("/%s/%s/%s", instance, database, table), "table")
+    expected = BrowseEntity.builder(table, String.format("/%s/%s/%s", instance, database, table), "table")
                    .canBrowse(false)
                    .canSample(true)
-                   .build())
-      .build();
-    Assert.assertEquals(expected, detail);
+                   .build();
+    Assert.assertTrue(detail.getEntities().contains(expected));
 
     // browse table
     detail = connector.browse(new MockConnectorContext(new MockConnectorConfigurer()),
                               BrowseRequest.builder(instance + "/" + database + "/" + table).build());
-    Assert.assertEquals(expected, detail);
+    Assert.assertTrue(detail.getEntities().contains(expected));
 
     // invalid path
     Assert.assertThrows(IllegalArgumentException.class, () ->

--- a/widgets/BigQueryExecute-action.json
+++ b/widgets/BigQueryExecute-action.json
@@ -254,6 +254,15 @@
             "default": "2",
             "placeholder": "The multiplier to use on retry attempts."
           }
+        },
+        {
+          "widget-type": "hidden",
+          "label": "Read Timeout",
+          "name": "readTimeout",
+          "widget-attributes": {
+            "default": "120",
+            "minimum": "0"
+          }
         }
       ]
     }


### PR DESCRIPTION
## Add validation for logical type (array/repeated)

Jira : [PLUGIN-1803](https://cdap.atlassian.net/browse/PLUGIN-1803)

### Description

When we have a BQ field with repeated logical type _(say array of dates)_ current validation only works primitive types, and it fails when `BQ.type (=DATE)` is compared with the primitive type `(INT for Date)` causing an invalid mismatch error.

### Code change

- Modified `BigQueryUtil.java`

### Unit Tests

- Modified `BigQueryUtilTest.java`
  -  testValidateFieldSchemaNotMatchesDate 
  - testValidateFieldSchemaMatchesDate
  
  
![image](https://github.com/user-attachments/assets/6c84be73-37f4-4337-b998-8324570f644e)


