### PR TITLE
[PLUGIN-1742] Add GCSEmptyInputFormat (Allow Empty Input)

### DIFF
--- a/docs/BigQueryTable-batchsink.md
+++ b/docs/BigQueryTable-batchsink.md
@@ -110,6 +110,17 @@ is ignored if the table already exists.
 **Time Partitioning Type**: Specifies the time partitioning type. Can either be Daily or Hourly or Monthly or Yearly.
 Default is Daily. Ignored when table already exists
 
+> The table below shows the compatibility of different time schema types with various time partitioning types in BigQuery.
+
+| Schema Type / Partion Type  | Hourly  | Daily   | Monthly | Yearly  |
+|-------------------------| ------- | ------- | ------- | ------- |
+| TIMESTAMP_MILLIS        | &check; | &check; | &check; | &check; |
+| TIMESTAMP_MICROS        | &check; | &check; | &check; | &check; |
+| DATETIME                | &check; | &check; | &check; | &check; |
+| DATE                    | &cross; | &check; | &check; | &check; |
+| TIME_MILLIS             | &cross; | &cross; | &cross; | &cross; |
+| TIME_MICROS             | &cross; | &cross; | &cross; | &cross; |
+
 **Range Start**: For integer partitioning, specifies the start of the range. Only used when table doesn’t 
 exist already, and partitioning type is set to Integer.
 * The start value is inclusive.

--- a/src/main/java/io/cdap/plugin/gcp/common/GCSEmptyInputFormat.java
+++ b/src/main/java/io/cdap/plugin/gcp/common/GCSEmptyInputFormat.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.plugin.gcp.common;
+
+import io.cdap.plugin.format.input.AbstractEmptyInputFormat;
+
+
+/**
+ * An InputFormat that returns no data.
+ * @param <K> the type of key
+ * @param <V> the type of value
+ */
+public class GCSEmptyInputFormat<K, V> extends AbstractEmptyInputFormat<K, V> {
+  // no-op
+}

--- a/src/main/java/io/cdap/plugin/gcp/gcs/source/GCSSource.java
+++ b/src/main/java/io/cdap/plugin/gcp/gcs/source/GCSSource.java
@@ -43,6 +43,7 @@ import io.cdap.plugin.format.plugin.AbstractFileSourceConfig;
 import io.cdap.plugin.format.plugin.FileSourceProperties;
 import io.cdap.plugin.gcp.common.GCPConnectorConfig;
 import io.cdap.plugin.gcp.common.GCPUtils;
+import io.cdap.plugin.gcp.common.GCSEmptyInputFormat;
 import io.cdap.plugin.gcp.crypto.EncryptedFileSystem;
 import io.cdap.plugin.gcp.gcs.GCSPath;
 import io.cdap.plugin.gcp.gcs.connector.GCSConnector;
@@ -75,6 +76,11 @@ public class GCSSource extends AbstractFileSource<GCSSource.GCSSourceConfig> {
   @Override
   public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
     super.configurePipeline(pipelineConfigurer);
+  }
+
+  @Override
+  protected String getEmptyInputFormatClassName() {
+    return GCSEmptyInputFormat.class.getName();
   }
 
   @Override
@@ -266,11 +272,6 @@ public class GCSSource extends AbstractFileSource<GCSSource.GCSSourceConfig> {
     @Nullable
     public Long getMinSplitSize() {
       return minSplitSize;
-    }
-
-    @Override
-    public boolean shouldAllowEmptyInput() {
-      return false;
     }
 
     public boolean isCopyHeader() {

--- a/src/test/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkConfigTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkConfigTest.java
@@ -130,6 +130,34 @@ public class BigQuerySinkConfigTest {
   }
 
   @Test
+  public void testValidateTimePartitioningColumnWithMonthAndDateTime() throws
+    InvocationTargetException, IllegalAccessException {
+
+    String columnName = "partitionFrom";
+    Schema schema = Schema.of(Schema.LogicalType.DATETIME);
+
+    Schema fieldSchema = schema.isNullable() ? schema.getNonNullable() : schema;
+    TimePartitioning.Type timePartitioningType = TimePartitioning.Type.MONTH;
+
+    validateTimePartitioningColumnMethod.invoke(config, columnName, collector, fieldSchema, timePartitioningType);
+    Assert.assertEquals(0, collector.getValidationFailures().size());
+  }
+
+  @Test
+  public void testValidateTimePartitioningColumnWithHourAndDateTime() throws
+    InvocationTargetException, IllegalAccessException {
+
+    String columnName = "partitionFrom";
+    Schema schema = Schema.of(Schema.LogicalType.DATETIME);
+
+    Schema fieldSchema = schema.isNullable() ? schema.getNonNullable() : schema;
+    TimePartitioning.Type timePartitioningType = TimePartitioning.Type.HOUR;
+
+    validateTimePartitioningColumnMethod.invoke(config, columnName, collector, fieldSchema, timePartitioningType);
+    Assert.assertEquals(0, collector.getValidationFailures().size());
+  }
+
+  @Test
   public void testValidateColumnNameWithValidColumnName() {
     String columnName = "test";
     Schema schema = Schema.recordOf("test", Schema.Field.of(columnName, Schema.of(Schema.Type.STRING)));


### PR DESCRIPTION
## Add GCSEmptyInputFormat (Allow Empty Input)

Jira : [PLUGIN-1742](https://cdap.atlassian.net/browse/PLUGIN-1742)

### Description

Add `GCSEmptyInputFormat` to allow user to run the pipeline with invalid source if `Allow Empty Input` is set to true.
- The pipeline would fail with an invalid source, when the option is set to false (default behavior)
  - Invalid source refers to a GCS path that does not exist
- This was hard coded to false to avoid the class loading error, which requires to add a separate `EmptyInputFormat`

### Code change

- Added `GCSEmptyInputFormat.java`
- Modified `GCSSource.java`
