### PR TITLE
[PLUGIN-1805] Fix TimePartitioningColumn DATETIME validation

### DIFF
--- a/docs/BigQueryTable-batchsink.md
+++ b/docs/BigQueryTable-batchsink.md
@@ -110,6 +110,17 @@ is ignored if the table already exists.
 **Time Partitioning Type**: Specifies the time partitioning type. Can either be Daily or Hourly or Monthly or Yearly.
 Default is Daily. Ignored when table already exists
 
+> The table below shows the compatibility of different time schema types with various time partitioning types in BigQuery.
+
+| Schema Type / Partion Type  | Hourly  | Daily   | Monthly | Yearly  |
+|-------------------------| ------- | ------- | ------- | ------- |
+| TIMESTAMP_MILLIS        | &check; | &check; | &check; | &check; |
+| TIMESTAMP_MICROS        | &check; | &check; | &check; | &check; |
+| DATETIME                | &check; | &check; | &check; | &check; |
+| DATE                    | &cross; | &check; | &check; | &check; |
+| TIME_MILLIS             | &cross; | &cross; | &cross; | &cross; |
+| TIME_MICROS             | &cross; | &cross; | &cross; | &cross; |
+
 **Range Start**: For integer partitioning, specifies the start of the range. Only used when table doesn’t 
 exist already, and partitioning type is set to Integer.
 * The start value is inclusive.

--- a/src/test/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkConfigTest.java
+++ b/src/test/java/io/cdap/plugin/gcp/bigquery/sink/BigQuerySinkConfigTest.java
@@ -130,6 +130,34 @@ public class BigQuerySinkConfigTest {
   }
 
   @Test
+  public void testValidateTimePartitioningColumnWithMonthAndDateTime() throws
+    InvocationTargetException, IllegalAccessException {
+
+    String columnName = "partitionFrom";
+    Schema schema = Schema.of(Schema.LogicalType.DATETIME);
+
+    Schema fieldSchema = schema.isNullable() ? schema.getNonNullable() : schema;
+    TimePartitioning.Type timePartitioningType = TimePartitioning.Type.MONTH;
+
+    validateTimePartitioningColumnMethod.invoke(config, columnName, collector, fieldSchema, timePartitioningType);
+    Assert.assertEquals(0, collector.getValidationFailures().size());
+  }
+
+  @Test
+  public void testValidateTimePartitioningColumnWithHourAndDateTime() throws
+    InvocationTargetException, IllegalAccessException {
+
+    String columnName = "partitionFrom";
+    Schema schema = Schema.of(Schema.LogicalType.DATETIME);
+
+    Schema fieldSchema = schema.isNullable() ? schema.getNonNullable() : schema;
+    TimePartitioning.Type timePartitioningType = TimePartitioning.Type.HOUR;
+
+    validateTimePartitioningColumnMethod.invoke(config, columnName, collector, fieldSchema, timePartitioningType);
+    Assert.assertEquals(0, collector.getValidationFailures().size());
+  }
+
+  @Test
   public void testValidateColumnNameWithValidColumnName() {
     String columnName = "test";
     Schema schema = Schema.recordOf("test", Schema.Field.of(columnName, Schema.of(Schema.Type.STRING)));


### PR DESCRIPTION
## Fix TimePartitioningColumn DATETIME validation

Jira : [PLUGIN-1805](https://cdap.atlassian.net/browse/PLUGIN-1805)

### Description

This datetime is a valid time format that can be used as the partion coloumn, this PR adds the column to validate function.


### Compatibility Matrix (with all time types)
- Partition Field Type / Time Partitioning Type

|                       | Hourly  | Daily   | Monthly | Yearly  |
| --------------------- | ------- | ------- | ------- | ------- |
| type_timestamp_millis | &check; | &check; | &check; | &check; |
| type_timestamp_micros | &check; | &check; | &check; | &check; |
| type_datetime         | &check; | &check; | &check; | &check; |
| type_date             | &cross; | &check; | &check; | &check; |
| type_time_millis      | &cross; | &cross; | &cross; | &cross; |
| type_time_micros      | &cross; | &cross; | &cross; | &cross; |

---

### Code change

- Modified `BigQuerySinkConfig.java`

### Unit Tests

- Modified `BigQuerySinkConfigTest.java`
	- testValidateTimePartitioningColumnWith`HourAndDateTime`
	- testValidateTimePartitioningColumnWith`MonthAndDateTime`

<img width="497" alt="image" src="https://github.com/user-attachments/assets/1f90d03f-d85e-487a-a9b6-4832f6ef2132">

